### PR TITLE
Move mock to package

### DIFF
--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -3,6 +3,6 @@ analysis pipelines. See the online documentation at
 https://mwvgroup.github.io/Egon/
 """
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -141,6 +141,26 @@ class Input(AbstractConnector):
         self._connected_partners = ObjectCollection()  # Tracks connector objects that feed into the input
 
     @property
+    def max_size(self) -> int:
+        """The maximum number of objects to store in the connector's memory
+
+        Once the maximum size is reached, the ``put`` method will block until
+        an item is moved from the connector into the node.
+        """
+
+        return self._queue._maxsize
+
+    @max_size.setter
+    def max_size(self, maxsize: int) -> None:
+        """Replaces the underlying queue with a new instance and updated
+        connected outputs to point at that new instance.
+        """
+
+        self._queue = mp.Queue(maxsize=maxsize)
+        for partner in self._connected_partners:
+            partner._queue = self._queue
+
+    @property
     def is_connected(self) -> bool:
         """Return whether the connector has any established connections"""
 

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -157,6 +157,9 @@ class Input(AbstractConnector):
         connected outputs to point at that new instance.
         """
 
+        if not self.empty():
+            raise RuntimeError('Cannot change maximum connector size when the connector is not empty.')
+
         self._queue = mp.Queue(maxsize=maxsize)
         for partner in self._connected_partners:
             partner._queue = self._queue

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -60,16 +60,17 @@ class ObjectCollection:
         """
 
         index = self._index_map[x]
-        del self._index_map[x]
 
         # Swap element with last element so that removal from the list can be done in O(1) time
         size = len(self._object_list)
         last = self._object_list[size - 1]
         self._object_list[index], self._object_list[size - 1] = self._object_list[size - 1], self._object_list[index]
-        del self._object_list[-1]
 
         # Update hash table for new index of last element
         self._index_map[last] = index
+
+        del self._index_map[x]
+        del self._object_list[-1]
 
     def __iter__(self) -> Iterable:
         return iter(self._object_list)

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -141,7 +141,7 @@ class Input(AbstractConnector):
         self._connected_partners = ObjectCollection()  # Tracks connector objects that feed into the input
 
     @property
-    def max_size(self) -> int:
+    def maxsize(self) -> int:
         """The maximum number of objects to store in the connector's memory
 
         Once the maximum size is reached, the ``put`` method will block until
@@ -150,8 +150,8 @@ class Input(AbstractConnector):
 
         return self._queue._maxsize
 
-    @max_size.setter
-    def max_size(self, maxsize: int) -> None:
+    @maxsize.setter
+    def maxsize(self, maxsize: int) -> None:
         """Replaces the underlying queue with a new instance and updated
         connected outputs to point at that new instance.
         """

--- a/egon/mock.py
+++ b/egon/mock.py
@@ -1,3 +1,8 @@
+"""The ``mock`` module defines prebuilt pipeline nodes for developing
+unittests. Instead of accomplishing a user defined action, mock nodes sleep
+for a pre-defined number of seconds.
+"""
+
 from asyncio import sleep
 
 from egon import nodes
@@ -28,7 +33,7 @@ class MockTarget(nodes.Target):
     def action(self) -> None:
         """Placeholder function to satisfy requirements of abstract parent"""
 
-        sleep(100)
+        sleep(10)
 
 
 class MockNode(nodes.Node):

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -41,6 +41,9 @@ class AbstractNode(abc.ABC):
     def __init__(self, num_processes=1) -> None:
         """Represents a single pipeline node"""
 
+        if num_processes < 0:
+            raise ValueError(f'Cannot instantiate a negative number of forked processes (got {num_processes}).')
+
         # Note that we use the memory address and not the ``pid`` attribute.
         # ``pid`` is only set after the process is started
         self._processes = [mp.Process(target=self.execute) for _ in range(num_processes)]
@@ -59,6 +62,9 @@ class AbstractNode(abc.ABC):
     @num_processes.setter
     def num_processes(self, num_processes) -> None:
         """The number of processes assigned to the current node"""
+
+        if num_processes < 0:
+            raise ValueError(f'Cannot instantiate a negative number of forked processes (got {num_processes}).')
 
         if any(p.is_alive() for p in self._processes):
             raise RuntimeError('Cannot change number of processes while node is running.')

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -12,29 +12,52 @@ class QueueProperties(TestCase):
     def setUp(self) -> None:
         """Create a ``DataStore`` instance"""
 
-        self.data_store = AbstractConnector(maxsize=1)
+        self.connector = AbstractConnector(maxsize=1)
 
     def test_size_matches_queue_size(self) -> None:
         """Test the ``size`` method returns the size of the queue`"""
 
-        self.assertEqual(self.data_store.size(), 0)
-        self.data_store._queue.put(1)
-        self.assertEqual(self.data_store.size(), 1)
+        self.assertEqual(self.connector.size(), 0)
+        self.connector._queue.put(1)
+        self.assertEqual(self.connector.size(), 1)
 
     def test_full_state(self) -> None:
         """Test the ``full`` method returns the state of the queue"""
 
-        self.assertFalse(self.data_store.full())
-        self.data_store._queue.put(1)
-        self.assertTrue(self.data_store.full())
+        self.assertFalse(self.connector.full())
+        self.connector._queue.put(1)
+        self.assertTrue(self.connector.full())
 
     def test_empty_state(self) -> None:
         """Test the ``empty`` method returns the state of the queue"""
 
-        self.assertTrue(self.data_store.empty())
-        self.data_store._queue.put(1)
+        self.assertTrue(self.connector.empty())
+        self.connector._queue.put(1)
 
         # The value of Queue.empty() updates asynchronously
         time.sleep(1)
 
-        self.assertFalse(self.data_store.empty())
+        self.assertFalse(self.connector.empty())
+
+    def test_maxsize(self) -> None:
+        """Test the max queue size is set at __init__"""
+
+        connector = AbstractConnector(maxsize=10)
+        self.assertEqual(connector._queue._maxsize, connector.max_size)
+
+
+class MaxQueueSize(TestCase):
+    """Tests the setting/getting of the maximum size for the underlying queue"""
+
+    def test_set_at_init(self) -> None:
+        """Test the max queue size is set at __init__"""
+
+        connector = AbstractConnector(maxsize=10)
+        self.assertEqual(10, connector.max_size)
+
+    def test_changed_via_setter(self) -> None:
+        """Test the size of the underlying queue is changed when setting the ``max_size`` attribute"""
+
+        connector = AbstractConnector(maxsize=10)
+        connector.max_size = 5
+        self.assertEqual(5, connector.max_size)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -38,26 +38,3 @@ class QueueProperties(TestCase):
         time.sleep(1)
 
         self.assertFalse(self.connector.empty())
-
-    def test_maxsize(self) -> None:
-        """Test the max queue size is set at __init__"""
-
-        connector = AbstractConnector(maxsize=10)
-        self.assertEqual(connector._queue._maxsize, connector.max_size)
-
-
-class MaxQueueSize(TestCase):
-    """Tests the setting/getting of the maximum size for the underlying queue"""
-
-    def test_set_at_init(self) -> None:
-        """Test the max queue size is set at __init__"""
-
-        connector = AbstractConnector(maxsize=10)
-        self.assertEqual(10, connector.max_size)
-
-    def test_changed_via_setter(self) -> None:
-        """Test the size of the underlying queue is changed when setting the ``max_size`` attribute"""
-
-        connector = AbstractConnector(maxsize=10)
-        connector.max_size = 5
-        self.assertEqual(5, connector.max_size)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,5 @@
+"""Tests the creation of pipeline nodes using function decorators."""
+
 import inspect
 from typing import Type
 from unittest import TestCase, skip

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,4 +1,4 @@
-"""Tests for connector objects defined in the ``connectors`` module"""
+"""Tests the connectivity and functionality of ``Input`` connector objects."""
 
 from unittest import TestCase
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,5 +1,5 @@
 """Tests the connectivity and functionality of ``Input`` connector objects."""
-
+from asyncio import sleep
 from unittest import TestCase
 
 from egon.connectors import KillSignal, Input, Output
@@ -125,21 +125,30 @@ class InputIterGet(TestCase):
 class MaxQueueSize(TestCase):
     """Tests the setting/getting of the maximum size for the underlying queue"""
 
+    def setUp(self) -> None:
+        self.connector = Input(maxsize=10)
+
     def test_maxsize(self) -> None:
         """Test the max queue size is set at __init__"""
 
-        connector = Input(maxsize=10)
-        self.assertEqual(connector._queue._maxsize, connector.maxsize)
+        self.assertEqual(self.connector._queue._maxsize, self.connector.maxsize)
 
     def test_set_at_init(self) -> None:
         """Test the max queue size is set at __init__"""
 
-        connector = Input(maxsize=10)
-        self.assertEqual(10, connector.maxsize)
+        self.assertEqual(10, self.connector.maxsize)
 
     def test_changed_via_setter(self) -> None:
         """Test the size of the underlying queue is changed when setting the ``maxsize`` attribute"""
 
-        connector = Input(maxsize=10)
-        connector.maxsize = 5
-        self.assertEqual(5, connector.maxsize)
+        self.connector.maxsize = 5
+        self.assertEqual(5, self.connector.maxsize)
+
+    def test_error_on_nonempty_queue(self) -> None:
+        """Test a ``RuntimeError`` is raised when changing the size of a nonempty connector"""
+
+        self.connector._queue.put(1)
+        sleep(1)  # Let the queue update
+
+        with self.assertRaises(RuntimeError):
+            self.connector.maxsize += 1

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,10 +1,9 @@
-from egon.connectors import KillSignal, Input, Output
-
 """Tests for connector objects defined in the ``connectors`` module"""
 
 from unittest import TestCase
 
-from tests.mock import MockSource, MockTarget
+from egon.connectors import KillSignal, Input, Output
+from egon.mock import MockSource, MockTarget
 
 
 class InstanceConnections(TestCase):

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -22,6 +22,16 @@ class InstanceConnections(TestCase):
         self.output_connector.connect(self.input_connector)
         self.assertTrue(self.input_connector.is_connected)
 
+    def test_queue_size_change(self) -> None:
+        """Test connected outputs point at the correct input queue after changing the queue size"""
+
+        input = Input(maxsize=10)
+        output = Output()
+        output.connect(input)
+
+        input.max_size = 5
+        self.assertIs(input._queue, output._queue)
+
 
 class PartnerMapping(TestCase):
     """Test connectors with an established connection correctly map to neighboring connectors/nodes"""

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -29,7 +29,7 @@ class InstanceConnections(TestCase):
         output = Output()
         output.connect(input)
 
-        input.max_size = 5
+        input.maxsize = 5
         self.assertIs(input._queue, output._queue)
 
 
@@ -120,3 +120,26 @@ class InputIterGet(TestCase):
         test_val = 'test_val'
         self.target.input._queue.put(test_val)
         self.assertEqual(next(self.target.input.iter_get()), test_val)
+
+
+class MaxQueueSize(TestCase):
+    """Tests the setting/getting of the maximum size for the underlying queue"""
+
+    def test_maxsize(self) -> None:
+        """Test the max queue size is set at __init__"""
+
+        connector = Input(maxsize=10)
+        self.assertEqual(connector._queue._maxsize, connector.maxsize)
+
+    def test_set_at_init(self) -> None:
+        """Test the max queue size is set at __init__"""
+
+        connector = Input(maxsize=10)
+        self.assertEqual(10, connector.maxsize)
+
+    def test_changed_via_setter(self) -> None:
+        """Test the size of the underlying queue is changed when setting the ``maxsize`` attribute"""
+
+        connector = Input(maxsize=10)
+        connector.maxsize = 5
+        self.assertEqual(5, connector.maxsize)

--- a/tests/test_mock_pipelines/__init__.py
+++ b/tests/test_mock_pipelines/__init__.py
@@ -1,3 +1,3 @@
-"""This directory contains fully functional pipelines that test the
+"""This directory contains prebuilt analysis pipelines for testing the
 end-to-end throughput of data through interconnected nodes.
 """

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,7 +1,7 @@
 from functools import partial
 from unittest import TestCase
 
-from . import mock
+from egon import mock
 
 
 class ProcessAllocation(TestCase):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,5 @@
+"""Tests for the class based construction of pipeline nodes."""
+
 from functools import partial
 from unittest import TestCase
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -33,6 +33,19 @@ class ProcessAllocation(TestCase):
         with self.assertRaises(RuntimeError):
             node.num_processes = 1
 
+    def test_error_on_negative_processes(self) -> None:
+        """Assert a value error is raised when the ``num_processes`` attribute is set to a negative"""
+
+        node = mock.MockNode(1)
+        with self.assertRaises(ValueError):
+            node.num_processes = -1
+
+    def test_error_on_negative_processes_at_init(self) -> None:
+        """Assert a value error is raised when a node is instantiated with a negative number"""
+
+        with self.assertRaises(ValueError):
+            mock.MockNode(-1)
+
 
 class Execution(TestCase):
     """Test the execution of tasks assigned to a Node instance"""

--- a/tests/test_node_validation.py
+++ b/tests/test_node_validation.py
@@ -1,3 +1,5 @@
+"""Tests the validation processes of pipelione nodes"""
+
 from unittest import TestCase, skip
 
 from egon import exceptions

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from egon import exceptions
 from egon.connectors import Input, Output
 from egon.exceptions import MissingConnectionError
-from tests.mock import MockSource, MockTarget
+from egon.mock import MockSource, MockTarget
 
 
 class InstanceConnections(TestCase):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,5 @@
+"""Tests the connectivity and functionality of ``Input`` connector objects."""
+
 from unittest import TestCase
 
 from egon import exceptions

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,9 +5,9 @@ from unittest import TestCase
 
 from egon.connectors import Output
 from egon.exceptions import OrphanedNodeError, MissingConnectionError
+from egon.mock import MockSource, MockNode, MockPipeline
 from egon.nodes import Node
 from egon.pipeline import Pipeline
-from tests.mock import MockSource, MockNode, MockPipeline
 
 
 class StartStopCommands(TestCase):


### PR DESCRIPTION
- Moves the mock module from the test-suite into the main package
- Allows the size of input queues to be changed after instantiation
- Raises value error when creating a node with negative processes
- Raises runtime error when changing the size of a nonempty connector 
- Adds missing docstring