### PR TITLE
0.2.2

### DIFF
--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -3,6 +3,6 @@ analysis pipelines. See the online documentation at
 https://mwvgroup.github.io/Egon/
 """
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'

--- a/egon/mock.py
+++ b/egon/mock.py
@@ -3,8 +3,6 @@ unittests. Instead of accomplishing a user defined action, mock nodes sleep
 for a pre-defined number of seconds.
 """
 
-from asyncio import sleep
-
 from egon import nodes
 from egon.connectors import Input, Output
 from egon.pipeline import Pipeline
@@ -13,14 +11,16 @@ from egon.pipeline import Pipeline
 class MockSource(nodes.Source):
     """A ``Source`` subclass that implements placeholder functions for abstract methods"""
 
-    def __init__(self, num_processes=1) -> None:
+    def __init__(self, load_data: list = None, num_processes=1) -> None:
         self.output = Output()
+        self.load_data = load_data
         super(MockSource, self).__init__(num_processes)
 
     def action(self) -> None:
         """Placeholder function to satisfy requirements of abstract parent"""
 
-        sleep(10)
+        for x in self.load_data:
+            self.output.put(x)
 
 
 class MockTarget(nodes.Target):
@@ -28,12 +28,14 @@ class MockTarget(nodes.Target):
 
     def __init__(self, num_processes=1) -> None:
         self.input = Input()
+        self.accumulated_data = []
         super(MockTarget, self).__init__(num_processes)
 
     def action(self) -> None:
         """Placeholder function to satisfy requirements of abstract parent"""
 
-        sleep(10)
+        for x in self.input.iter_get():
+            self.accumulated_data.append(x)
 
 
 class MockNode(nodes.Node):
@@ -47,7 +49,8 @@ class MockNode(nodes.Node):
     def action(self) -> None:
         """Placeholder function to satisfy requirements of abstract parent"""
 
-        sleep(10)
+        for x in self.input.iter_get():
+            self.output.put(x)
 
 
 class MockPipeline(Pipeline):

--- a/egon/mock.py
+++ b/egon/mock.py
@@ -11,9 +11,9 @@ from egon.pipeline import Pipeline
 class MockSource(nodes.Source):
     """A ``Source`` subclass that implements placeholder functions for abstract methods"""
 
-    def __init__(self, load_data: list = None, num_processes=1) -> None:
+    def __init__(self, load_data: list = None, num_processes=0) -> None:
         self.output = Output()
-        self.load_data = load_data
+        self.load_data = load_data or []
         super(MockSource, self).__init__(num_processes)
 
     def action(self) -> None:
@@ -26,7 +26,7 @@ class MockSource(nodes.Source):
 class MockTarget(nodes.Target):
     """A ``Target`` subclass that implements placeholder functions for abstract methods"""
 
-    def __init__(self, num_processes=1) -> None:
+    def __init__(self, num_processes=0) -> None:
         self.input = Input()
         self.accumulated_data = []
         super(MockTarget, self).__init__(num_processes)
@@ -41,7 +41,7 @@ class MockTarget(nodes.Target):
 class MockNode(nodes.Node):
     """A ``Node`` subclass that implements placeholder functions for abstract methods"""
 
-    def __init__(self, num_processes=1) -> None:
+    def __init__(self, num_processes=0) -> None:
         self.output = Output()
         self.input = Input()
         super(MockNode, self).__init__(num_processes)

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -28,7 +28,7 @@ class ProcessAllocation(TestCase):
     def test_error_if_processes_are_alive(self) -> None:
         """Test a RuntimeError is raised when trying to reallocate processes on a running node"""
 
-        node = mock.MockNode()
+        node = mock.MockNode(num_processes=1)
         node._processes[0].start()
         with self.assertRaises(RuntimeError):
             node.num_processes = 1
@@ -53,7 +53,7 @@ class Execution(TestCase):
     def setUp(self) -> None:
         """Create a testing node that tracks the execution method of it's methods"""
 
-        self.node = mock.MockNode()
+        self.node = mock.MockNode(num_processes=1)
 
         # Track the call order of node functions
         self.call_list = []


### PR DESCRIPTION
- Adds the `load_data: list` argument to the `MockSource` class. Instances will now load all objects from the `load_data` argument into the `MockSource.output` connector.
- Adds the `accumulated_data: list` attribute to the `MockTarget` class. `MockTarget` instances will populate the new attribute with any data passed to `MockTarget.input` connector.
- `MockNode` now acts as a direct connection between the `MockNode.input` and `MockNode.output` connectors.
- Changes default number of processes for mock objects to 0 so they default to running sequentially.