### PR TITLE
Adds a two second pause before marking a process as finished

### DIFF
--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -3,6 +3,6 @@ analysis pipelines. See the online documentation at
 https://mwvgroup.github.io/Egon/
 """
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 __author__ = 'Daniel Perrefort'
 __license__ = 'GPL 3.0'

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -44,7 +44,7 @@ class AbstractConnector:
 
         return bool(self._connected_partners)
 
-    def get_partners(self) -> List[Output]:
+    def get_partners(self) -> List:
         """Return a list of connectors that are connected to this instance"""
 
         return list(self._connected_partners)

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -144,7 +144,7 @@ class AbstractNode(abc.ABC):
     def teardown(self) -> None:
         """Teardown tasks called after running ``action``"""
 
-    def _set_process_finished(self):
+    def _set_process_finished(self) -> None:
         """Record the parent process as having finished executing analysis tasks"""
 
         sleep(2)  # Allow any ``put`` calls to finish populating the queue
@@ -184,7 +184,7 @@ class AbstractNode(abc.ABC):
     def __repr__(self) -> str:  # pragma: no cover
         return f'{self.__class__.__name__}(num_processes={self.num_processes})'
 
-    def __del__(self):
+    def __del__(self) -> None:
         if any(p.is_alive() for p in self._processes):
             raise RuntimeError(f'Cannot delete a node while it is running (del called on node {self})')
 

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -9,6 +9,7 @@ import abc
 import inspect
 import multiprocessing as mp
 from abc import ABC
+from time import sleep
 from typing import Collection, List, Union
 
 from . import connectors, exceptions
@@ -143,6 +144,12 @@ class AbstractNode(abc.ABC):
     def teardown(self) -> None:
         """Teardown tasks called after running ``action``"""
 
+    def _set_process_finished(self):
+        """Record the parent process as having finished executing analysis tasks"""
+
+        sleep(2)  # Allow any ``put`` calls to finish populating the queue
+        self.process_finished = True
+
     def execute(self) -> None:
         """Execute the pipeline node
 
@@ -152,7 +159,7 @@ class AbstractNode(abc.ABC):
         self.setup()
         self.action()
         self.teardown()
-        self.process_finished = True
+        self._set_process_finished()
 
     def expecting_data(self) -> bool:
         """Return whether the node is still expecting data from upstream"""

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -160,8 +160,8 @@ class AbstractNode(abc.ABC):
         for input_connector in self._get_attrs(connectors.Input):
             # IMPORTANT: The order of the following code blocks is crucial
             # We check for any running upstream nodes first
-            for partner in input_connector.get_partners():
-                if not partner.parent_node.node_finished:
+            for output_connector in input_connector.get_partners():
+                if not output_connector.parent_node.node_finished:
                     return True
 
             # Check for any unprocessed data once we know there are no

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,7 +1,6 @@
 """Tests the connectivity and functionality of ``Input`` connector objects."""
 
 import time
-from asyncio import sleep
 from unittest import TestCase
 
 from egon.connectors import Input, KillSignal, Output
@@ -155,7 +154,7 @@ class MaxQueueSize(TestCase):
         """Test a ``RuntimeError`` is raised when changing the size of a nonempty connector"""
 
         self.connector._queue.put(1)
-        sleep(2)  # Let the queue update
+        time.sleep(2)  # Let the queue update
 
         with self.assertRaises(RuntimeError):
             self.connector.maxsize += 1


### PR DESCRIPTION
This allows any `put` calls to finish populating the queue before the node exits.