### PR TITLE
Makes process_finished attribute read only

### DIFF
--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -91,11 +91,17 @@ class AbstractNode(abc.ABC):
     def process_finished(self) -> bool:
         """Return whether the current process has finished processing data"""
 
+        return self._process_finished
+
+    @property
+    def _process_finished(self) -> bool:
+        """Return whether the current process has finished processing data"""
+
         # Use get in case called from a process not forked by the class __init__
         return self._states.get(mp.current_process().pid, self._current_process_state)
 
-    @process_finished.setter
-    def process_finished(self, state: bool) -> None:
+    @_process_finished.setter
+    def _process_finished(self, state: bool) -> None:
         sleep(2)  # Allow any ``put`` calls to finish populating the queue
         self._states[id(mp.current_process())] = self._current_process_state = state
 
@@ -106,7 +112,7 @@ class AbstractNode(abc.ABC):
         # Check that all forked processes are finished, including the current process
         # Checking the current process is necessary in case the node is run in Main
         if self.num_processes == 0:
-            return self.process_finished
+            return self._process_finished
 
         return all(self._states.values())
 
@@ -171,7 +177,7 @@ class AbstractNode(abc.ABC):
         self.setup()
         self.action()
         self.teardown()
-        self.process_finished = True
+        self._process_finished = True
 
     def expecting_data(self) -> bool:
         """Return whether the node is still expecting data from upstream"""

--- a/tests/test_connectors/test_input.py
+++ b/tests/test_connectors/test_input.py
@@ -34,7 +34,7 @@ class InputGet(TestCase):
         source = MockSource(num_processes=0)
         target = MockTarget(num_processes=0)  # Run node in current process only
         source.output.connect(target.input)
-        source.process_finished = True
+        source._process_finished = True
 
         self.assertFalse(target.expecting_data())
         self.assertIs(target.input.get(timeout=15), KillSignal)

--- a/tests/test_nodes/test_generic.py
+++ b/tests/test_nodes/test_generic.py
@@ -69,7 +69,7 @@ class Execution(TestCase):
         self.assertListEqual(self.call_list, expected_order)
 
     def test_process_is_finished_on_execute(self) -> None:
-        """Test the ``process_finished`` property is updated after node execution"""
+        """Test the ``_process_finished`` property is updated after node execution"""
 
         self.assertFalse(self.node.process_finished, 'Default finished state is not False.')
         self.node.execute()
@@ -125,25 +125,25 @@ class ExpectingData(TestCase):
     def test_false_for_empty_queue_and_finished_parent(self) -> None:
         """Test the return is False for a EMPTY queue and a FINISHED PARENT node"""
 
-        self.root.process_finished = True
+        self.root._process_finished = True
         self.assertFalse(self.node.expecting_data())
 
     def test_true_if_input_queue_has_data(self) -> None:
         """Test the return is True for a NOT EMPTY queue and a FINISHED PARENT node"""
 
-        self.root.process_finished = True
+        self.root._process_finished = True
         self.node.input._queue.put(5)
         self.assertTrue(self.node.expecting_data())
 
     def test_true_if_parent_is_running(self) -> None:
         """Test the return is True for a EMPTY queue and a NOT FINISHED PARENT node"""
 
-        self.root.process_finished = False
+        self.root._process_finished = False
         self.assertTrue(self.node.expecting_data())
 
     def test_true_if_input_queue_has_data_and_parent_is_running(self) -> None:
         """Test the return is True for a NOT EMPTY queue and a NOT FINISHED PARENT node"""
 
-        self.root.process_finished = False
+        self.root._process_finished = False
         self.node.input._queue.put(5)
         self.assertTrue(self.node.expecting_data())


### PR DESCRIPTION
Closes #13 by implementing changes suggested in that issue.