### PR TITLE
Support running in main

### DIFF
--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -76,14 +76,25 @@ class MPool:
         # Check that all forked processes are finished
         return all(self._states.values())
 
+    def _raise_if_zero(self, action):
+        """Raise an error if pool size is zero"""
+
+        if self.num_processes == 0:
+            raise RuntimeError(f'Pool has zero assigned processes. No processes available to {action}')
+
     def start(self) -> None:
         """Start all processes asynchronously"""
 
+        self._raise_if_zero('start')
         for p in self._processes:
             p.start()
 
     def join(self) -> None:
         """Wait for any running pool processes to finish running before continuing execution"""
+
+        self._raise_if_zero('join')
+        if self.num_processes == 0:
+            raise RuntimeError('Pool has zero assigned processes. No processes available to join')
 
         for p in self._processes:
             p.join()
@@ -91,6 +102,7 @@ class MPool:
     def kill(self) -> None:
         """Kill all running processes without trying to exit gracefully"""
 
+        self._raise_if_zero('kill')
         for p in self._processes:
             p.terminate()
 

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -40,8 +40,8 @@ class MPool:
             target: The function to be executed by the allocated processes
         """
 
-        if num_processes <= 0:
-            raise ValueError(f'Cannot instantiate less than 1 forked processes (got {num_processes}).')
+        if num_processes < 0:
+            raise ValueError(f'Cannot instantiate negative forked processes (got {num_processes}).')
 
         # Note that we use the memory address of the processes and not the
         # ``pid`` attribute. ``pid`` is only set after the process is started.
@@ -101,10 +101,11 @@ class AbstractNode(abc.ABC):
     def __init__(self, name: str = None, num_processes: int = 1) -> None:
         """Represents a single pipeline node"""
 
-        self._pool = MPool(num_processes, self.execute)
-        self.num_processes = self._pool.num_processes
+        self._pool: MPool = MPool(num_processes, self.execute)
+        self._allow_pool_overwrite = True
         self.name = name or self.__class__.__name__
 
+        # Accumulate all attributes that are Input or Output types
         self._inputs = []
         self._outputs = []
         for connector in self._get_attrs(connectors.BaseConnector):
@@ -140,6 +141,19 @@ class AbstractNode(abc.ABC):
                     attr_list.append(attr)
 
         return attr_list
+
+    @property
+    def num_processes(self) -> int:
+        """The number of processes assigned to the pool"""
+
+        return self._pool.num_processes
+
+    @num_processes.setter
+    def num_processes(self, val) -> None:
+        if not self._allow_pool_overwrite:
+            raise RuntimeError('Cannot change number of processes on running or finished node')
+
+        self._pool = MPool(val, self.execute)
 
     @property
     def connectors(self) -> Tuple[Tuple[connectors.Input, ...], Tuple[connectors.Output, ...]]:
@@ -199,6 +213,7 @@ class AbstractNode(abc.ABC):
         Execution includes all ``setup``, ``action``, and ``teardown`` tasks.
         """
 
+        self._allow_pool_overwrite = False
         self.setup()
         self.action()
         self.teardown()
@@ -210,6 +225,13 @@ class AbstractNode(abc.ABC):
 
     def is_expecting_data(self) -> bool:
         """Return whether the node is still expecting data from upstream"""
+
+        if self.num_processes == 0:
+            for input_connector in self._get_attrs(connectors.Input):
+                if not input_connector.is_empty():
+                    return True
+
+            return False
 
         for input_connector in self._get_attrs(connectors.Input):
             # IMPORTANT: The order of the following code blocks is crucial

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -114,7 +114,7 @@ class AbstractNode(abc.ABC):
         """Represents a single pipeline node"""
 
         self._pool: MPool = MPool(num_processes, self.execute)
-        self._allow_pool_overwrite = True
+        self._allow_pool_overwrite = True  # See setter for ``num_processes`` attribute
         self.name = name or self.__class__.__name__
 
         # Accumulate all attributes that are Input or Output types
@@ -231,19 +231,20 @@ class AbstractNode(abc.ABC):
         self.teardown()
 
     def is_finished(self) -> bool:
-        """Return whether all node processes have finished processing data"""
+        """Return whether all node processes have finished processing data
+
+        The returned value defaults to ``True`` when the number of processes
+        assigned to the node instance is zero.
+        """
 
         return self._pool.is_finished()
 
     def is_expecting_data(self) -> bool:
-        """Return whether the node is still expecting data from upstream"""
+        """Return whether the node is still expecting data from upstream
 
-        if self.num_processes == 0:
-            for input_connector in self._get_attrs(connectors.Input):
-                if not input_connector.is_empty():
-                    return True
-
-            return False
+        This function includes checks for whether any upstream nodes are still
+        running or any data is pending in the queue of an input connector.
+        """
 
         for input_connector in self._get_attrs(connectors.Input):
             # IMPORTANT: The order of the following code blocks is crucial

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -31,15 +31,14 @@ class ProcessAllocation(TestCase):
         with self.assertRaises(ValueError):
             MPool(-1, target_func)
 
-    def test_error_on_zero_processes(self) -> None:
-        """Assert a value error is raised when the ``num_processes`` attribute is set to zero"""
-
-        with self.assertRaises(ValueError):
-            MPool(0, target_func)
-
 
 class Execution(TestCase):
     """Tests for the starting, running, and stopping of allocated processes"""
+
+    def test_pool_is_finished_for_zero_processes(self) -> None:
+        """Test the ``is_finished`` is true for a pool with zero processes"""
+
+        self.assertTrue(MPool(0, target_func).is_finished)
 
     def test_pool_is_finished_after_execution(self) -> None:
         """Test the ``is_finished`` property is updated after the pool executes"""

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -35,11 +35,6 @@ class ProcessAllocation(TestCase):
 class Execution(TestCase):
     """Tests for the starting, running, and stopping of allocated processes"""
 
-    def test_pool_is_finished_for_zero_processes(self) -> None:
-        """Test the ``is_finished`` is true for a pool with zero processes"""
-
-        self.assertTrue(MPool(0, target_func).is_finished)
-
     def test_pool_is_finished_after_execution(self) -> None:
         """Test the ``is_finished`` property is updated after the pool executes"""
 
@@ -63,3 +58,34 @@ class Execution(TestCase):
         self.assertTrue(
             pool._processes[0].exitcode < 0,
             f'Process not ended by termination signal ({pool._processes[0].exitcode})')
+
+
+class ZeroProcessPool(TestCase):
+    """Tests for pool behavior with zero processes"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pool = MPool(0, target_func)
+
+    def test_pool_is_finished_by_default(self) -> None:
+        """Test the ``is_finished`` is true for a pool with zero processes"""
+
+        self.assertTrue(MPool(0, target_func).is_finished)
+
+    def test_run_error(self):
+        """Test running the pool with zero processes raises an error"""
+
+        with self.assertRaises(RuntimeError):
+            self.pool.start()
+
+    def test_join_error(self):
+        """Test joining the pool with zero processes raises an error"""
+
+        with self.assertRaises(RuntimeError):
+            self.pool.join()
+
+    def test_kill_error(self):
+        """Test killing the pool with zero processes raises an error"""
+
+        with self.assertRaises(RuntimeError):
+            self.pool.kill()


### PR DESCRIPTION
- Allows nodes to be assigned zero forked processes thus allowing them to be run in the main process without always being marked as incomplete.
-  Extends test suite to cover new behavior