### PR TITLE
Moves to Ray for multiprocessing backend

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -3,7 +3,7 @@ analysis pipelines. See the online documentation at
 https://mwvgroup.github.io/Egon/
 """
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 __author__ = 'MWV Research Group'
 __license__ = 'GPL 3.0'
 

--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -15,4 +15,4 @@ except ImportError:
     warnings.warn('Ray must be installed to use the egon package.')
 
 else:
-    ray.init(ignore_reinit_error=True, include_dashboard=False)
+    ray.init(ignore_reinit_error=True, include_dashboard=False, log_to_driver=False, logging_level=50)

--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -7,12 +7,19 @@ __version__ = '0.6.0'
 __author__ = 'MWV Research Group'
 __license__ = 'GPL 3.0'
 
+import warnings
+
 try:
-    import ray
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        import ray
 
 except ImportError:
-    import warnings
     warnings.warn('Ray must be installed to use the egon package.')
 
 else:
-    ray.init(ignore_reinit_error=True, include_dashboard=False, log_to_driver=False, logging_level=50)
+    ray.init(
+        ignore_reinit_error=True,
+        include_dashboard=False,
+        log_to_driver=False,
+        logging_level=50)

--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -7,6 +7,12 @@ __version__ = '0.5.0'
 __author__ = 'MWV Research Group'
 __license__ = 'GPL 3.0'
 
-import ray
+try:
+    import ray
 
-ray.init(ignore_reinit_error=True, include_dashboard=False)
+except ImportError:
+    import warnings
+    warnings.warn('Ray must be installed to use the egon package.')
+
+else:
+    ray.init(ignore_reinit_error=True, include_dashboard=False)

--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -6,3 +6,7 @@ https://mwvgroup.github.io/Egon/
 __version__ = '0.5.0'
 __author__ = 'MWV Research Group'
 __license__ = 'GPL 3.0'
+
+import ray
+
+ray.init(ignore_reinit_error=True, include_dashboard=False)

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -7,12 +7,13 @@ type of connector. ``Output`` connectors are used to send data and
 
 from __future__ import annotations
 
-import multiprocessing as mp
-from queue import Empty
 from typing import Any, Optional, TYPE_CHECKING, Tuple
 
-from .utils import KillSignal, ObjectCollection
+from ray.util.queue import Empty
+from ray.util.queue import Queue
+
 from .exceptions import MissingConnectionError, OverwriteConnectionError
+from .utils import KillSignal, ObjectCollection
 
 if TYPE_CHECKING:  # pragma: no cover
     from .nodes import AbstractNode
@@ -66,7 +67,7 @@ class Input(BaseConnector):
 
         super().__init__(name=name)
         self._maxsize = maxsize
-        self._queue = mp.Queue(maxsize=maxsize)
+        self._queue = Queue(maxsize=maxsize)
 
     def is_empty(self) -> bool:
         """Return if the connection queue is empty"""
@@ -91,7 +92,7 @@ class Input(BaseConnector):
         an item is moved from the connector into the node.
         """
 
-        return self._queue._maxsize
+        return self._queue.maxsize
 
     @maxsize.setter
     def maxsize(self, maxsize: int) -> None:
@@ -101,7 +102,7 @@ class Input(BaseConnector):
         if not self.is_empty():
             raise RuntimeError('Cannot change maximum connector size when the connector is not empty.')
 
-        self._queue = mp.Queue(maxsize=maxsize)
+        self._queue = Queue(maxsize=maxsize)
 
     def get(self, timeout: Optional[int] = None, refresh_interval: int = 2):
         """Blocking call to retrieve input data

--- a/egon/decorators.py
+++ b/egon/decorators.py
@@ -34,7 +34,7 @@ class WrappedSource(nodes.Source):
 
     def __init__(self, func: GeneratorFunction) -> None:
         self.output = connectors.Output()
-        self._func = _as_single_arg_func(func)
+        self._func: GeneratorFunction = _as_single_arg_func(func)
         super().__init__()
 
     def action(self) -> None:

--- a/egon/mock.py
+++ b/egon/mock.py
@@ -14,25 +14,47 @@ class Mock(AbstractNode, ABC):
     """Base class for mock testing nodes"""
 
     def __init__(self) -> None:
-        self._is_finished = False
+        self._is_running = False
         super(Mock, self).__init__()
 
-    def is_finished(self) -> bool:
-        """Return whether the mock node has already been executed"""
+    def set_running_state(self, state: bool) -> None:
+        """Set the return value of the ``is_running`` method
 
-        return self._is_finished
+        Args:
+            state: The returned running state
+        """
+
+        self._is_running = state
+
+    def is_running(self) -> bool:
+        """Return if any node processes are still processing data
+
+        This is a mock value that can be changed using the
+        ``set_running_state`` function. Mock node values do not create
+        spawned processes.
+        """
+
+        return self._is_running
 
     def execute(self) -> None:
         """Execute the mock pipeline node"""
 
         super(Mock, self).execute()
-        self._is_finished = True
 
 
 class MockSource(Mock, nodes.Source):
-    """A ``Source`` subclass that implements placeholder functions for abstract methods"""
+    """A mock ``Source`` node for use in testing"""
 
     def __init__(self, load_data: list = None) -> None:
+        """A Mock Source node with a single output connector
+
+        On execution, data from the ``load_data`` argument is loaded into the
+        ``output`` connector.
+
+        Args:
+            load_data: Data to load into the output connector
+        """
+
         self.output = Output()
         self.load_data = load_data or []
         super(MockSource, self).__init__()
@@ -45,9 +67,15 @@ class MockSource(Mock, nodes.Source):
 
 
 class MockTarget(Mock, nodes.Target):
-    """A ``Target`` subclass that implements placeholder functions for abstract methods"""
+    """A mock ``Target`` node for use in testing"""
 
     def __init__(self) -> None:
+        """A Mock ``Target`` node with a single input connector
+
+        On execution, data from the ``input`` connector is loaded into the
+        ``accumulated_data`` attribute.
+        """
+
         self.input = Input()
         self.accumulated_data = []
         super(MockTarget, self).__init__()
@@ -60,9 +88,15 @@ class MockTarget(Mock, nodes.Target):
 
 
 class MockNode(Mock, nodes.Node):
-    """A ``Node`` subclass that implements placeholder functions for abstract methods"""
+    """A mock ``Node`` object for use in testing"""
 
     def __init__(self) -> None:
+        """A Mock ``Target`` node with an input and output connector
+
+        On execution, data from the ``input`` connector is loaded into the
+        ``output`` connector.
+        """
+
         self.output = Output()
         self.input = Input()
         super(MockNode, self).__init__()

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 import abc
 from abc import ABC
 from itertools import chain
-from time import sleep
-from typing import Collection, Optional
+from typing import Collection
 from typing import List, Tuple, Union
 
-from ray.util.multiprocessing.pool import AsyncResult, Pool
-
 from . import connectors, exceptions
+from .parallel import MPool
 
 
 def _get_nodes_from_connectors(connector_list: Collection[connectors.BaseConnector]) -> Tuple:
@@ -28,76 +26,6 @@ def _get_nodes_from_connectors(connector_list: Collection[connectors.BaseConnect
     """
 
     return tuple(p.parent_node for c in connector_list for p in c.partners)
-
-
-class MPool:
-    """A pool of processes assigned to a single target function"""
-
-    def __init__(self, num_processes: int, target: callable) -> None:
-        """Create a collection of processes assigned to execute a given callable
-
-        Args:
-            num_processes: The number of processes to allocate
-            target: The function to be executed by the allocated processes
-        """
-
-        if num_processes <= 0:
-            raise ValueError(f'Cannot instantiate less than one processes in a pool (got {num_processes}).')
-
-        self._pool: Optional[Pool] = None
-        self._pool_future: Optional[AsyncResult] = None
-        self._num_processes = num_processes
-        self._target = target
-
-    def _call_target(self) -> None:  # pragma: nocover, Called from forked process
-        """Wrapper for calling the pool's target function"""
-
-        self._target()
-
-    @property
-    def num_processes(self) -> int:
-        """The number of processes assigned to the pool"""
-
-        return self._num_processes
-
-    @property
-    def target(self) -> callable:
-        """The callable to be executed by the pool"""
-
-        return self._target
-
-    def is_finished(self) -> bool:
-        """Return whether all processes have finished executing"""
-
-        # Check that all forked processes are finished
-        return (self._pool_future is not None) and self._pool_future.ready()
-
-    def start(self) -> None:
-        """Start all processes asynchronously"""
-
-        if self._pool is not None:
-            raise RuntimeError('Pool is already running')
-
-        self._pool = Pool(ray_address="auto", processes=self.num_processes)
-        self._pool_future = self._pool.apply_async(self._call_target)
-        self._pool.close()
-
-    def join(self) -> None:
-        """Wait for any running pool processes to finish running before continuing execution"""
-
-        if self._pool_future is None or self._pool_future.ready():
-            raise RuntimeError('Pool is not running')
-
-        self._pool.join()
-
-    def kill(self) -> None:
-        """Kill all running processes without trying to exit gracefully"""
-
-        if self._pool_future is None or self._pool_future.ready():
-            raise RuntimeError('Pool is not running')
-
-        self._pool.terminate()
-        sleep(1)
 
 
 class AbstractNode(abc.ABC):

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -6,12 +6,12 @@ that produce, analyze, and consume data respectively.
 from __future__ import annotations
 
 import abc
-import multiprocessing as mp
 from abc import ABC
 from itertools import chain
-from time import sleep
-from typing import Collection
+from typing import Collection, Optional
 from typing import List, Tuple, Union
+
+from ray.util.multiprocessing import Pool
 
 from . import connectors, exceptions
 
@@ -43,10 +43,8 @@ class MPool:
         if num_processes < 0:
             raise ValueError(f'Cannot instantiate negative forked processes (got {num_processes}).')
 
-        # Note that we use the memory address of the processes and not the
-        # ``pid`` attribute. ``pid`` is only set after the process is started.
-        self._processes = [mp.Process(target=self._call_target) for _ in range(num_processes)]
-        self._states = mp.Manager().dict({id(p): False for p in self._processes})
+        self._pool: Optional[Pool] = None
+        self._num_processes = num_processes
         self._target = target
 
     def _call_target(self) -> None:  # pragma: nocover, Called from forked process
@@ -54,15 +52,11 @@ class MPool:
 
         self._target()
 
-        # Mark the current process as being finished
-        sleep(.5)  # Allow any last minute calls to finish before changing the state
-        self._states[id(mp.current_process())] = True
-
     @property
     def num_processes(self) -> int:
         """The number of processes assigned to the pool"""
 
-        return len(self._processes)
+        return self._num_processes
 
     @property
     def target(self) -> callable:
@@ -74,37 +68,29 @@ class MPool:
         """Return whether all processes have finished executing"""
 
         # Check that all forked processes are finished
-        return all(self._states.values())
-
-    def _raise_if_zero(self, action):
-        """Raise an error if pool size is zero"""
-
-        if self.num_processes == 0:
-            raise RuntimeError(f'Pool has zero assigned processes. No processes available to {action}')
+        return (self._pool is not None) and self._pool._closed
 
     def start(self) -> None:
         """Start all processes asynchronously"""
 
-        self._raise_if_zero('start')
-        for p in self._processes:
-            p.start()
+        self._pool = Pool(ray_address="auto", processes=self.num_processes)
+        self._pool.apply_async(self._call_target)
 
     def join(self) -> None:
         """Wait for any running pool processes to finish running before continuing execution"""
 
-        self._raise_if_zero('join')
-        if self.num_processes == 0:
-            raise RuntimeError('Pool has zero assigned processes. No processes available to join')
+        if not self._pool or self._pool._closed:
+            raise RuntimeError('Pool is not running')
 
-        for p in self._processes:
-            p.join()
+        self._pool.join()
 
     def kill(self) -> None:
         """Kill all running processes without trying to exit gracefully"""
 
-        self._raise_if_zero('kill')
-        for p in self._processes:
-            p.terminate()
+        if not self._pool or self._pool._closed:
+            raise RuntimeError('Pool is not running')
+
+        self._pool.terminate()
 
 
 class AbstractNode(abc.ABC):

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -11,7 +11,7 @@ from itertools import chain
 from typing import Collection, Optional
 from typing import List, Tuple, Union
 
-from ray.util.multiprocessing import Pool
+from ray.util.multiprocessing.pool import AsyncResult, Pool
 
 from . import connectors, exceptions
 
@@ -44,6 +44,7 @@ class MPool:
             raise ValueError(f'Cannot instantiate less than one processes in a pool (got {num_processes}).')
 
         self._pool: Optional[Pool] = None
+        self._pool_future: Optional[AsyncResult] = None
         self._num_processes = num_processes
         self._target = target
 
@@ -68,18 +69,23 @@ class MPool:
         """Return whether all processes have finished executing"""
 
         # Check that all forked processes are finished
-        return (self._pool is not None) and self._pool._closed
+        print(self._pool_future.ready())
+        return (self._pool_future is not None) and self._pool_future.ready()
 
     def start(self) -> None:
         """Start all processes asynchronously"""
 
+        if self._pool is not None:
+            raise RuntimeError('Pool is already running')
+
         self._pool = Pool(ray_address="auto", processes=self.num_processes)
-        self._pool.apply_async(self._call_target)
+        self._pool_future = self._pool.apply_async(self._call_target)
+        self._pool.close()
 
     def join(self) -> None:
         """Wait for any running pool processes to finish running before continuing execution"""
 
-        if not self._pool or self._pool._closed:
+        if self._pool_future is None or self._pool_future.ready():
             raise RuntimeError('Pool is not running')
 
         self._pool.join()
@@ -87,7 +93,7 @@ class MPool:
     def kill(self) -> None:
         """Kill all running processes without trying to exit gracefully"""
 
-        if not self._pool or self._pool._closed:
+        if self._pool_future is None or self._pool_future.ready():
             raise RuntimeError('Pool is not running')
 
         self._pool.terminate()

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -152,16 +152,12 @@ class AbstractNode(abc.ABC):
         self.teardown()
 
     def is_running(self) -> bool:
-        """Return if any node processes are still processing data
-
-        The returned value defaults to ``True`` when the number of processes
-        assigned to the node instance is zero.
-        """
+        """Return if any node processes are still processing data"""
 
         return self._pool.is_running()
 
     def is_expecting_data(self) -> bool:
-        """Return whether the node is still expecting data from upstream
+        """Return if the node is expecting data from any nodes running upstream
 
         This function includes checks for whether any upstream nodes are still
         running or any data is pending in the queue of an input connector.

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import abc
 from abc import ABC
 from itertools import chain
+from time import sleep
 from typing import Collection, Optional
 from typing import List, Tuple, Union
 
@@ -69,7 +70,6 @@ class MPool:
         """Return whether all processes have finished executing"""
 
         # Check that all forked processes are finished
-        print(self._pool_future.ready())
         return (self._pool_future is not None) and self._pool_future.ready()
 
     def start(self) -> None:
@@ -97,6 +97,7 @@ class MPool:
             raise RuntimeError('Pool is not running')
 
         self._pool.terminate()
+        sleep(1)
 
 
 class AbstractNode(abc.ABC):

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -151,14 +151,14 @@ class AbstractNode(abc.ABC):
         self.action()
         self.teardown()
 
-    def is_finished(self) -> bool:
-        """Return whether all node processes have finished processing data
+    def is_running(self) -> bool:
+        """Return if any node processes are still processing data
 
         The returned value defaults to ``True`` when the number of processes
         assigned to the node instance is zero.
         """
 
-        return self._pool.is_finished()
+        return self._pool.is_running()
 
     def is_expecting_data(self) -> bool:
         """Return whether the node is still expecting data from upstream
@@ -171,7 +171,7 @@ class AbstractNode(abc.ABC):
             # IMPORTANT: The order of the following code blocks is crucial
             # We check for any running upstream nodes first
             for output_connector in input_connector.partners:
-                if not output_connector.parent_node.is_finished():
+                if output_connector.parent_node.is_running():
                     return True
 
             # Check for any unprocessed data once we know there are no

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -40,8 +40,8 @@ class MPool:
             target: The function to be executed by the allocated processes
         """
 
-        if num_processes < 0:
-            raise ValueError(f'Cannot instantiate negative forked processes (got {num_processes}).')
+        if num_processes <= 0:
+            raise ValueError(f'Cannot instantiate less than one processes in a pool (got {num_processes}).')
 
         self._pool: Optional[Pool] = None
         self._num_processes = num_processes

--- a/egon/parallel.py
+++ b/egon/parallel.py
@@ -1,3 +1,5 @@
+"""Utilities for running code in parallel"""
+
 from __future__ import annotations
 
 from time import sleep
@@ -8,15 +10,24 @@ from ray import ObjectRef
 
 
 class Actor:
+    """Worker object responsible for executing tasks a remote machine"""
 
     def __init__(self, fun: callable) -> None:
+        """Worker object responsible for executing tasks a remote machine
+
+        Args:
+            fun: The callable to be executed by the actor
+        """
+
         self._fun = fun
 
     @ray.remote
-    def _act(self) -> None:
+    def _act(self) -> Optional:
         return self._fun()
 
-    def act(self) -> None:
+    def act(self) -> Optional:
+        """Run the actor remotely"""
+
         return self._act.remote(self)
 
 
@@ -50,15 +61,15 @@ class MPool:
         return self._pool is not None
 
     def is_finished(self) -> bool:
-        """Return whether all processes have finished executing"""
+        """Return whether all processes have finished running"""
 
-        return self.is_started() and all(remote.future().done() for remote in self._pool)
+        return self.is_started() and not any(remote.future().running() for remote in self._pool)
 
     def start(self) -> None:
         """Start all processes asynchronously"""
 
         if self.is_started():
-            raise RuntimeError('Pool was already started')
+            raise RuntimeError('Pool was already started once before')
 
         self._pool = [self._actor.act() for _ in range(self._num_processes)]
 
@@ -66,7 +77,7 @@ class MPool:
         """Wait for any running pool processes to finish running before continuing execution"""
 
         if not self.is_started() or self.is_finished():
-            raise RuntimeError('Pool is not running')
+            raise RuntimeError('Pool is not running.')
 
         for remote in self._pool:
             ray.get(remote)
@@ -74,8 +85,10 @@ class MPool:
     def kill(self) -> None:
         """Kill all running processes without trying to exit gracefully"""
 
-        if self._pool_future is None or self._pool_future.ready():
-            raise RuntimeError('Pool is not running')
+        if not self.is_started() or self.is_finished():
+            raise RuntimeError('Pool is not running.')
 
-        self._pool.terminate()
+        for remote in self._pool:
+            remote.future().cancel()
+
         sleep(1)

--- a/egon/parallel.py
+++ b/egon/parallel.py
@@ -58,7 +58,7 @@ class MPool:
     def is_running(self) -> bool:
         """Return whether the ``start`` method has already been called"""
 
-        return self._pool is not None and any(remote.future().running() for remote in self._pool)
+        return self._pool is not None and not any(remote.future().done() or remote.future().cancelled() for remote in self._pool)
 
     def start(self) -> None:
         """Start all processes asynchronously"""

--- a/egon/parallel.py
+++ b/egon/parallel.py
@@ -55,20 +55,15 @@ class MPool:
 
         return self._num_processes
 
-    def is_started(self) -> bool:
+    def is_running(self) -> bool:
         """Return whether the ``start`` method has already been called"""
 
-        return self._pool is not None
-
-    def is_finished(self) -> bool:
-        """Return whether all processes have finished running"""
-
-        return self.is_started() and not any(remote.future().running() for remote in self._pool)
+        return self._pool is not None and any(remote.future().running() for remote in self._pool)
 
     def start(self) -> None:
         """Start all processes asynchronously"""
 
-        if self.is_started():
+        if self.is_running():
             raise RuntimeError('Pool was already started once before')
 
         self._pool = [self._actor.act() for _ in range(self._num_processes)]
@@ -76,19 +71,11 @@ class MPool:
     def join(self) -> None:
         """Wait for any running pool processes to finish running before continuing execution"""
 
-        if not self.is_started() or self.is_finished():
-            raise RuntimeError('Pool is not running.')
-
         for remote in self._pool:
             ray.get(remote)
 
     def kill(self) -> None:
         """Kill all running processes without trying to exit gracefully"""
 
-        if not self.is_started() or self.is_finished():
-            raise RuntimeError('Pool is not running.')
-
-        for remote in self._pool:
-            remote.future().cancel()
-
+        ray.kill(self._actor)
         sleep(1)

--- a/egon/parallel.py
+++ b/egon/parallel.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from time import sleep
+from typing import List, Optional
+
+import ray
+from ray import ObjectRef
+
+
+class Actor:
+
+    def __init__(self, fun: callable) -> None:
+        self._fun = fun
+
+    @ray.remote
+    def _act(self) -> None:
+        return self._fun()
+
+    def act(self) -> None:
+        return self._act.remote(self)
+
+
+class MPool:
+    """A pool of processes assigned to a single target function"""
+
+    def __init__(self, num_processes: int, target: callable) -> None:
+        """Create a collection of processes assigned to execute a given callable
+
+        Args:
+            num_processes: The number of processes to allocate
+            target: The function to be executed by the allocated processes
+        """
+
+        if num_processes <= 0:
+            raise ValueError(f'Cannot instantiate less than one processes in a pool (got {num_processes}).')
+
+        self._num_processes = num_processes
+        self._actor = Actor(target)
+        self._pool: Optional[List[ObjectRef]] = None
+
+    @property
+    def num_processes(self) -> int:
+        """The number of processes assigned to the pool"""
+
+        return self._num_processes
+
+    def is_started(self) -> bool:
+        """Return whether the ``start`` method has already been called"""
+
+        return self._pool is not None
+
+    def is_finished(self) -> bool:
+        """Return whether all processes have finished executing"""
+
+        return self.is_started() and all(remote.future().done() for remote in self._pool)
+
+    def start(self) -> None:
+        """Start all processes asynchronously"""
+
+        if self.is_started():
+            raise RuntimeError('Pool was already started')
+
+        self._pool = [self._actor.act() for _ in range(self._num_processes)]
+
+    def join(self) -> None:
+        """Wait for any running pool processes to finish running before continuing execution"""
+
+        if not self.is_started() or self.is_finished():
+            raise RuntimeError('Pool is not running')
+
+        for remote in self._pool:
+            ray.get(remote)
+
+    def kill(self) -> None:
+        """Kill all running processes without trying to exit gracefully"""
+
+        if self._pool_future is None or self._pool_future.ready():
+            raise RuntimeError('Pool is not running')
+
+        self._pool.terminate()
+        sleep(1)

--- a/egon/pipeline.py
+++ b/egon/pipeline.py
@@ -15,6 +15,8 @@ from inspect import getmembers
 from itertools import chain
 from typing import List, Tuple
 
+import ray
+
 from . import connectors as conn
 from . import nodes
 from .visualize import Visualizer
@@ -23,7 +25,19 @@ from .visualize import Visualizer
 class Pipeline:
     """Manages a collection of nodes as a single analysis pipeline"""
 
-    def __init__(self) -> None:
+    def __init__(self, address: str = None) -> None:
+        """Base class for a data analysis pipeline constructed of multiple interconnected nodes
+
+        The pipeline will run on a single machine by default and will
+        automatically detect the available hardware resources. For instructions
+        on how to configure the available resources and/or run on a cluster
+        environment, see the official docs: https://mwvgroup.github.io/Egon/
+
+        Args:
+            address: Optionally specify the address of the ray cluster to run on
+        """
+
+        self.address = address
 
         # Store the nodes and connectors used to build the pipeline
         # so they can be exposed by public accessors
@@ -113,6 +127,7 @@ class Pipeline:
     def run_async(self) -> None:
         """Start all processes asynchronously"""
 
+        ray.init(address=self.address, ignore_reinit_error=True)
         for node in chain(*self.nodes):
             node._pool.start()
 

--- a/egon/pipeline.py
+++ b/egon/pipeline.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from asyncio.subprocess import Process
 from copy import copy
 from inspect import getmembers
 from itertools import chain
@@ -68,16 +67,6 @@ class Pipeline:
         for node in chain(*self.nodes):
             node.validate()
 
-    def _get_processes(self) -> List[Process]:
-        """Return a list of processes forked by pipeline nodes"""
-
-        # Collect all of the processes assigned to each node
-        processes = []
-        for node in chain(*self.nodes):
-            processes.extend(node._pool._processes)
-
-        return processes
-
     @property
     def nodes(self) -> Tuple[Tuple[nodes.Source], Tuple[nodes.Node], Tuple[nodes.Target]]:
         """Return a list of all nodes in the pipeline
@@ -104,13 +93,13 @@ class Pipeline:
     def num_processes(self) -> int:
         """The number of processes forked by to the pipeline"""
 
-        return len(self._get_processes())
+        return sum(node._pool.num_processes for node in chain(*self.nodes) if node._pool is not None)
 
     def kill(self) -> None:
         """Kill all running pipeline processes without trying to exit gracefully"""
 
-        for p in self._get_processes():
-            p.terminate()
+        for node in chain(*self.nodes):
+            node._pool.terminate()
 
     def run(self) -> None:
         """Start all pipeline processes and block execution until all processes exit"""

--- a/egon/pipeline.py
+++ b/egon/pipeline.py
@@ -140,6 +140,7 @@ class Pipeline:
         from waitress import serve
 
         if not quiet:
+            # noinspection HttpUrlsUsage
             print(f'Launching server at http://{host}:{port}')
 
         # we increase the number of threads from 4 (the default) to 8 so the

--- a/egon/utils.py
+++ b/egon/utils.py
@@ -1,6 +1,6 @@
 """Generic utility classes"""
 
-from typing import Hashable, Collection, Iterable, Optional
+from typing import Collection, Hashable, Iterable, Optional
 
 
 class KillSignal:

--- a/egon/visualize/callbacks.py
+++ b/egon/visualize/callbacks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional, TYPE_CHECKING, Tuple
+from typing import List, Optional, TYPE_CHECKING, Tuple, cast
 
 import numpy as np
 import psutil
@@ -51,7 +51,7 @@ class SystemUsage(BaseGraphCallback):
 
         now = datetime.now()
         y = np.transpose([psutil.cpu_percent(percpu=True)])
-        x = np.full_like(y, now, dtype=datetime)
+        x = np.full_like(y, cast(now, float), dtype=datetime)
         return dict(x=x, y=y), None, self.max_data
 
     # noinspection PyUnusedLocal
@@ -90,5 +90,5 @@ class PipelineStatus(BaseGraphCallback):
 
         now = datetime.now()
         y = [[c.size()] for c in self._connector_list]
-        x = np.full_like(y, now, dtype=datetime)
+        x = np.full_like(y, cast(now, float), dtype=datetime)
         return dict(x=x, y=y), None, self.max_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 boltons>=20.2.1
 dash>=1.20.0
 dash_cytoscape>=0.2.0
-egon>=0.3.1
 numpy>=1.20.1
 pyyaml>=5.4.1
 pandas
 plotly>=4.14.3
-ray[default]
+ray
 psutil>=5.8.0
 setuptools>=51.0.0
 waitress

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ boltons>=20.2.1
 dash>=1.20.0
 dash_cytoscape>=0.2.0
 egon>=0.3.1
+numpy>=1.20.1
 pyyaml>=5.4.1
 pandas
 plotly>=4.14.3
+ray[default]
 psutil>=5.8.0
-dash>=1.20.0
-numpy>=1.20.1
 setuptools>=51.0.0
 waitress

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 """Test suite for the Egon package."""
 
+import logging
 import unittest
+import warnings
 
 import ray
 
@@ -10,7 +12,11 @@ OLD_TEST_RUN = unittest.result.TestResult.startTestRun
 def startTestRun(self) -> None:
     """Instantiate ray so test can be run against a mock ray cluster"""
 
-    ray.init(num_cpus=4)
+    # Block resource warnings raised by a bug in some ray versions
+    # See https://github.com/ray-project/ray/issues/9546
+    warnings.filterwarnings('ignore', category=ResourceWarning, module='ray')
+
+    ray.init(num_cpus=4, logging_level=logging.ERROR)
 
 
 unittest.result.TestResult.startTestRun = startTestRun

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+"""Test suite for the Egon package."""
+
+import unittest
+
+import ray
+
+OLD_TEST_RUN = unittest.result.TestResult.startTestRun
+
+
+def startTestRun(self) -> None:
+    """Instantiate ray so test can be run against a mock ray cluster"""
+
+    ray.init(num_cpus=4)
+
+
+unittest.result.TestResult.startTestRun = startTestRun

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ def startTestRun(self) -> None:
     # See https://github.com/ray-project/ray/issues/9546
     warnings.filterwarnings('ignore', category=ResourceWarning, module='ray')
 
-    ray.init(num_cpus=4, logging_level=logging.ERROR)
+    ray.init(num_cpus=4, logging_level=logging.ERROR, ignore_reinit_error=True, include_dashboard=False)
 
 
 unittest.result.TestResult.startTestRun = startTestRun

--- a/tests/test_connectors/test_input.py
+++ b/tests/test_connectors/test_input.py
@@ -90,7 +90,7 @@ class MaxSize(TestCase):
     def test_queue_matches_input(self) -> None:
         """Test the max size of the underlying queue matches the max size of the Input"""
 
-        self.assertEqual(self.connector._queue._maxsize, self.connector.maxsize)
+        self.assertEqual(self.connector._queue.maxsize, self.connector.maxsize)
 
     def test_set_at_init(self) -> None:
         """Test the max queue size is set at __init__"""

--- a/tests/test_nodes/test_abstract_node.py
+++ b/tests/test_nodes/test_abstract_node.py
@@ -59,8 +59,14 @@ class TreeNavigation(TestCase):
 class ExpectingData(TestCase):
     """Tests for the ``is_expecting_data`` function
 
-    The ``is_expecting_data`` function combines two booleans.
-    This class evaluates all four squares of the corresponding truth table
+    These tests verify the following truth table for an inclusive or.
+
+    Parent Node Running | Queue not Empty || Is Expecting Data
+    --------------------|-----------------||-------------------
+              T         |        T        ||        T
+              T         |        F        ||        T
+              F         |        T        ||        T
+              F         |        F        ||        F
     """
 
     def setUp(self) -> None:
@@ -71,29 +77,39 @@ class ExpectingData(TestCase):
         self.root.output.connect(self.node.input)
 
     def test_false_for_empty_queue_and_finished_parent(self) -> None:
-        """Test the return is False for a EMPTY queue and a FINISHED PARENT node"""
+        """Test the return is False for a EMPTY queue and a NOT RUNNING parent"""
 
-        self.root.execute()
+        self.assertFalse(self.root.is_running())
+        self.assertFalse(self.node.input._queue)
         self.assertFalse(self.node.is_expecting_data())
 
     def test_true_if_input_queue_has_data(self) -> None:
-        """Test the return is True for a NOT EMPTY queue and a FINISHED PARENT node"""
+        """Test the return is True for a NOT EMPTY queue and a NOT RUNNING parent"""
 
-        self.root.execute()
         self.node.input._queue.put(5)
         sleep(1)  # Give the queue an opportunity to update
 
+        self.assertFalse(self.root.is_running())
+        self.assertTrue(self.node.input._queue)
         self.assertTrue(self.node.is_expecting_data())
 
-    def test_true_if_parent_is_running(self) -> None:
-        """Test the return is True for a EMPTY queue and a NOT FINISHED PARENT node"""
+    def test_false_if_parent_is_not_running(self) -> None:
+        """Test the return is True for a EMPTY queue and a RUNNING node"""
 
+        self.root.set_running_state(True)
+        self.assertTrue(self.root.is_running())
+        self.assertFalse(self.node.input._queue)
         self.assertTrue(self.node.is_expecting_data())
 
     def test_true_if_input_queue_has_data_and_parent_is_running(self) -> None:
-        """Test the return is True for a NOT EMPTY queue and a NOT FINISHED PARENT node"""
+        """Test the return is True for a NOT EMPTY queue and a RUNNING node"""
 
+        self.root.set_running_state(True)
         self.node.input._queue.put(5)
+        sleep(1)  # Give the queue an opportunity to update
+
+        self.assertTrue(self.root.is_running())
+        self.assertTrue(self.node.input._queue)
         self.assertTrue(self.node.is_expecting_data())
 
 

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -41,8 +41,9 @@ class Execution(TestCase):
         self.assertFalse(pool.is_finished(), 'Default finished state is not False.')
 
         pool.start()
-        pool.join()
+        self.assertFalse(pool.is_finished())
 
+        pool.join()
         self.assertTrue(pool.is_finished())
 
     def test_processes_killed_on_command(self) -> None:
@@ -51,9 +52,5 @@ class Execution(TestCase):
         pool = MPool(1, lambda *args: sleep(10))
         pool.start()
         pool.kill()
-        pool.join()
 
-        self.assertFalse(pool.is_finished())
-        self.assertTrue(
-            pool._processes[0].exitcode < 0,
-            f'Process not ended by termination signal ({pool._processes[0].exitcode})')
+        self.assertTrue(pool.is_finished())

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -23,7 +23,6 @@ class ProcessAllocation(TestCase):
         """Test the correct number of processes are allocated at init"""
 
         self.assertEqual(self.num_processes, self.pool.num_processes)
-        self.assertEqual(self.num_processes, len(self.pool._processes))
 
     def test_error_on_negative_processes(self) -> None:
         """Assert a value error is raised when the ``num_processes`` attribute is set to a negative"""
@@ -58,34 +57,3 @@ class Execution(TestCase):
         self.assertTrue(
             pool._processes[0].exitcode < 0,
             f'Process not ended by termination signal ({pool._processes[0].exitcode})')
-
-
-class ZeroProcessPool(TestCase):
-    """Tests for pool behavior with zero processes"""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.pool = MPool(0, target_func)
-
-    def test_pool_is_finished_by_default(self) -> None:
-        """Test the ``is_finished`` is true for a pool with zero processes"""
-
-        self.assertTrue(MPool(0, target_func).is_finished)
-
-    def test_run_error(self):
-        """Test running the pool with zero processes raises an error"""
-
-        with self.assertRaises(RuntimeError):
-            self.pool.start()
-
-    def test_join_error(self):
-        """Test joining the pool with zero processes raises an error"""
-
-        with self.assertRaises(RuntimeError):
-            self.pool.join()
-
-    def test_kill_error(self):
-        """Test killing the pool with zero processes raises an error"""
-
-        with self.assertRaises(RuntimeError):
-            self.pool.kill()

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -51,6 +51,7 @@ class Execution(TestCase):
 
         pool = MPool(1, lambda *args: sleep(10))
         pool.start()
-        pool.kill()
+        self.assertFalse(pool.is_finished())
 
+        pool.kill()
         self.assertTrue(pool.is_finished())

--- a/tests/test_nodes/test_mpool.py
+++ b/tests/test_nodes/test_mpool.py
@@ -29,29 +29,3 @@ class ProcessAllocation(TestCase):
 
         with self.assertRaises(ValueError):
             MPool(-1, target_func)
-
-
-class Execution(TestCase):
-    """Tests for the starting, running, and stopping of allocated processes"""
-
-    def test_pool_is_finished_after_execution(self) -> None:
-        """Test the ``is_finished`` property is updated after the pool executes"""
-
-        pool = MPool(2, target_func)
-        self.assertFalse(pool.is_finished(), 'Default finished state is not False.')
-
-        pool.start()
-        self.assertFalse(pool.is_finished())
-
-        pool.join()
-        self.assertTrue(pool.is_finished())
-
-    def test_processes_killed_on_command(self) -> None:
-        """Test processes are killed on demand"""
-
-        pool = MPool(1, lambda *args: sleep(10))
-        pool.start()
-        self.assertFalse(pool.is_finished())
-
-        pool.kill()
-        self.assertTrue(pool.is_finished())

--- a/tests/test_pipeline/test_linear_pipeline.py
+++ b/tests/test_pipeline/test_linear_pipeline.py
@@ -2,7 +2,7 @@
 through to the end.
 """
 
-from multiprocessing import Queue
+from ray.util.queue import Queue
 from unittest import TestCase
 
 from egon.decorators import as_node, as_source, as_target

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -24,23 +24,14 @@ class SimplePipeline(Pipeline):
 class ProcessDiscovery(TestCase):
     """Test the pipeline is aware of all processes forked by it's nodes"""
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.pipeline = SimplePipeline()
-        cls.expected_processes = []
-        cls.expected_processes.extend(cls.pipeline.source._pool._processes)
-        cls.expected_processes.extend(cls.pipeline.inline._pool._processes)
-        cls.expected_processes.extend(cls.pipeline.target._pool._processes)
+    def runTest(self) -> None:
+        pipeline = SimplePipeline()
+        expected_processes = \
+            pipeline.source._pool.num_processes + \
+            pipeline.inline._pool.num_processes + \
+            pipeline.target._pool.num_processes
 
-    def test_collected_processes_match_nodes(self) -> None:
-        """Test ``_get_processes`` returns forked processes from all pipeline nodes"""
-
-        self.assertCountEqual(self.expected_processes, self.pipeline._get_processes())
-
-    def test_process_count(self) -> None:
-        """Test the pipelines process count matches the sum of processes allocated to each node"""
-
-        self.assertEqual(len(self.expected_processes), self.pipeline.num_processes)
+        self.assertEqual(expected_processes, pipeline.num_processes)
 
 
 class NodeDiscovery(TestCase):


### PR DESCRIPTION
Replaces all usage of the builtin `multiprocessing` library with the `ray` library. This adds support for running on a cluster.

Other changes:
- Replaces `is_finished` methods with `is_running`
- The running state of mock nodes can now be set with the `set_running_state` method
- Parallelization logic is moved to the `parallel` module